### PR TITLE
Fix compatibility issue with B&A

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,163 +1,199 @@
-v1.1.2
-- Add compatibility for Better Victory Screen (by stringweasel)
-
-v1.1.1
-- Minor corrections to the technology pre-requisites when using Bobs mods courtesy of KiwiHawk.
-
-v1.1.0
-- Version 1.1 compatibility
-
-v1.0.0
-- Correction to assembly robot icon size
-
-v0.5.1
-- Russian language translation update
-
-v0.5.0
-- Version 0.18 compatibility
-
-v0.4.4
-- Changes dependencies to accomodate Bob;s new Personnal Equipment Mod.  You now need Personnal Equipment.  You now do not need Warfare.  If personnal equipment mod is missing, then the Bob;s mods recipes will not be activated.
-
-v0.4.3
-- Adds new map mod settings (ie change while playing) to allow for the suppression of the narrative messages.  Suppress narrative Popups will remove the message after completion of the satellite network and completion of the drydock.  Auto continue will suppress the final message and automatically choose to continue with another launch (Ie Bring it on).
-
-v0.4.2
-- Fixed the missing descriptions on technologies ftl D1 and ftl D2
-- Added thumbnail
-
-v0.4.1
-- Compatibility for 0.17 extended for bob's mods
-
-v0.4.0
-- Compatibility for v0.17 (not including bob's mods)
-
-v0.3.18 
-- Fixes invalid entity error on spacex combinator 
-- Fixes text on the Habitation component description
-
-v0.3.15
-- technology icon resolution upgrade coutesy of drd_avel
-
-v0.3.14
-- Fixes a crash if spacex combinator is placed prior to launching a single rocket.
-- Adds command "Get_log_file" which will write your SpaceX log out to the script-output folder.
-
-v0.3.13 Redacted
-
-v0.3.12
-- Fixes a rare crash on rocket launch event.
-
-v0.3.11
-- Fixes an error on game close out
-
-v0.3.10
-- Added Russian language support courtesy of Zerggurat
-- Performance issues with the SpaceX combinator resolved
-
-v0.3.9 Redacted
-
-v0.3.8
-- Remove spacex combinator debug information
-
-v0.3.7
-- improved grammar in flavour text
-- SpaceX Combinator introduced - will give accurate signal for current components needed to complete the current SpaceX phase. Current SpaceX phase given through virtual signal S - 1,2 or 3. Can be used to set filters/requester chests etc
-
-v0.3.6
-- under the Bob's mods integration, the technology price for faster than light theory D was incorrectly priced
-- under some circumstances the tech and recipe price multipliers were not working correctly
-- the data handling has been reduced with the removal of data-updates script
-
-v0.3.5
-- the mod now works correctly in conjunction with scenarios that do not use silo script
-- the mod now allows for multiple launching of SpaceX rockets - when the final SpaceX component is launched the player (or admin player in multiplayer scenario) is presented with an option to reset the SpaceX production counter, or end the game (latter option still offers the standard vanilla end game screen with options that include continue game, but in this case the SpaceX counter will not reset)
-- the command "/resetSpaceX" will allow you to resume SpaceX launches on a map that has previously completed the full process (eg under an earlier version of this mod, or even on this version by mistake for example)
-- multiple SpaceX launches are logged with playtime stamp and ability to name/describe the launch event
-- Flavour text added to SpaceX milestones courtesy of JD-Plays
-- Oh, yes, Bob's mod integration is back baby!
-- New mod setting allows for switching off bobs mods integration in case it causes any issues
-- Bob coefficient inflates the cost of end game research under Bob mods integration to partially offset extreme over powered nature of end game Bobs mods. Currently, this coefficient is set to 10. In the hands of a good player, the highest tier bobs mods machines, modules, beacons and other easily provide 150 -250+ times the power of vanilla equivalents, so the coefficient at 10 is a very conservative clawback.
-
-v0.3.4 
-- launches after completing the spaceship victory will not spam victory message
-- mod now supports mod_gui (refer ff#174)
-- colour and alignment added to Space Progress Summary
-
-v0.3.3 redacted
-
-v0.3.2
-- v0.16 compatibility
-- fix for headless server issue on configuration changed
-
-v0.3.1
-- Adds space science packs to last research (Faster than light propulsion systems)
-- Minor update to mod start conditions
-- In the start conditions, can opt out of having space science requirement in last SpaceX research
-- In the start conditions can adjust the cost of the fusion reactor to 40 portable fusion reactors - this reduces the cost of the component so that it is equivalent to the cost it was under v0.14 (10k processing units instead of 25k processing units)
-- In the start conditions can discount the tech costs by 4x to compensate for the marathon mode tech cost increases (at the default level). ie players can choose to use marathon costs for the vanilla game, and still use the standard tech costs once they start the SpaceX researches.
-
-v0.3.0
-
-- v0.15 compatibility
-- suppressed launch without satellite message
-- SpaceX components can be auto launched with "auto launch with satellite setting" in rocket silo
-- ftl drive moved to last position of Space Progress Summary
-- In space progress summary Hull sections renamed to Hull components to match name of item
-- item icons all changed to 32x32 square to conform with v0.15 standards
-- Mod configuration added - research costs and production costs can be independently increased by multiples of 2 upto 16x classic cost. Required number of launches can be increased by 5x or by 25x - note all these launches require the base item, so effectively production cost and extended launches multiply together. These options are available from the mod settings menu.
-
-v0.2.3
-
-- Corrected size of technology graphics so now they all look as intended rather than just left top corner
-- Bob's mods technology/recipes will not be activated unless the following minimum Bob's modules are in use -
-Bob's library
-Bob's modules
-Bob's warfare
-Bob'e electronics
-- this should fix any issues with "unusual" combinations of Bob's mods
-
-v0.2.2
-
-Graphics update courtesy of Steinerrr
-- New technology icons for all 15 techs (counting ftl as 4 techs)
-- New item icons for Assembly robot, Drydock Structural Component, Drydock Assembly Component, Hull Component, Protection Field, Fusion Reactor, Spaceship Thruster, Fuel Cell, Command Center, FTL Drive 
-
-
-v0.2.1
-
-- Fixed an issue where the Drydock completed message could be prematurely generated
-- Fixed an issue where Angels infinite ores used without Bobs mods caused an error on loading factorio
-- Bob's mods integration - added an alternate recipe for the spaceship protection field to remove the (excessive) multi-colored alien goo farming required
-
-v0.2.0
-
-- Fixed space progress reference to Drydock Command - this is now identified as the Drydock assembly component (like the item that needs to be launched
-- Corrected endgame console victory message for minor spelling error in "achieved"
-- Fixed the graphic for the life support icon
-
-- Added Bob's Mod integration based on bob's mod configuration:
-- Satellite recipe uses radar 5s, advanced processing unit, large solar panel mk 3s,large accumulator mk 3s
-- Low density structure uses titanium and nitinol in the place of steel and copper
-- Habitation component uses titanium and advanced processing unit to replace steel and processing unit
-- Fuel cell component uses titanium and advanced processing unit to replace steel and processing unit
-- Protection field component uses energy shield mk 6 to replace energy shield mk 2
-- Hull component uses titanium in place of steel
-- Fusion Reactor component uses fusion reactor mk 4 in place of fusion reactor equipment
-- Drydock assembly component uses large solar panel mk3, roboport mk 4, and advanced processing units in place of vanila items
-- All module requirements become god module 5s if god modules employed, otherwise the lvl 8 module version is used in the following -
-- Assembly robot which also uses construction robot mk 4
-- Space thruster which also uses titanium pipe and advanced processing unit
-- Life support which also uses titanium pipe and advanced processing unit
-- Command Centre which also uses advanced processing unit
-- Astrometrics which also uses advanced processing unit
-- FTL drive which also uses advanced processing unit
-- Bob's mods technology changes
-- if the dark blue science pack is available then all SpaceX techs that required the 4 vanilla sciences now also require dark blue
-- in addition, the ftl drive becomes 5 parts of 200k research each
-- SpaceX research is adjusted to include pre-requisites to the appropriate bob's mods techs
-- Space Assembly technology has the module pre-requisites added
-- Rocket silo now also requires titanium process, nitinol processing, electric energy accumulators mk4 , solar energy mk 4, advanced electronics 3, and radars 4
-- Space Construction additionally needs Modular robo ports 4
-- Protection fields needs Energy shield equipment mk 6
-- Fusion reactor needs Fusion Reactor equipment mk 4
+---------------------------------------------------------------------------------------------------
+Version: 1.1.2
+  Changes:
+    - Add compatibility for Better Victory Screen (by stringweasel)
+---------------------------------------------------------------------------------------------------
+Version: 1.1.1
+  Bugfixes:
+    - Minor corrections to the technology pre-requisites when using Bobs mods courtesy of KiwiHawk.
+---------------------------------------------------------------------------------------------------
+Version: 1.1.0
+  Changes:
+    - Version 1.1 compatibility
+---------------------------------------------------------------------------------------------------
+Version: 1.0.0
+  Bugfixes:
+    - Correction to assembly robot icon size
+---------------------------------------------------------------------------------------------------
+Version: 0.5.1
+  Changes:
+    - Russian language translation update
+---------------------------------------------------------------------------------------------------
+Version: 0.5.0
+  Changes:
+    - Version 0.18 compatibility
+---------------------------------------------------------------------------------------------------
+Version: 0.4.4
+  Changes:
+    - Changes dependencies to accomodate Bob's new Personnal Equipment Mod.  You now need Personnal Equipment.  You now do not need Warfare. If personnal equipment mod is missing, then the Bob's mods recipes will not be activated.
+---------------------------------------------------------------------------------------------------
+Version: 0.4.3
+  Changes:
+    - Adds new map mod settings (ie change while playing) to allow for the suppression of the narrative messages.  Suppress narrative Popups will remove the message after completion of the satellite network and completion of the drydock.  Auto continue will suppress the final message and automatically choose to continue with another launch (Ie Bring it on).
+---------------------------------------------------------------------------------------------------
+Version: 0.4.2
+  Bugfixes:
+    - Fixed the missing descriptions on technologies ftl D1 and ftl D2
+  Changes:
+    - Added thumbnail
+---------------------------------------------------------------------------------------------------
+Version: 0.4.1
+  Changes:
+    - Compatibility for 0.17 extended for Bob's mods
+---------------------------------------------------------------------------------------------------
+Version: 0.4.0
+  Changes:
+    - Compatibility for v0.17 (not including Bob's mods)
+---------------------------------------------------------------------------------------------------
+Version: 0.3.18 
+  Bugfixes:
+    - Fixes invalid entity error on spacex combinator 
+    - Fixes text on the Habitation component description
+---------------------------------------------------------------------------------------------------
+Version: 0.3.15
+  Changes:
+    - Technology icon resolution upgrade coutesy of drd_avel
+---------------------------------------------------------------------------------------------------
+Version: 0.3.14
+  Bugfixes:
+    - Fixes a crash if spacex combinator is placed prior to launching a single rocket.
+  Changes:
+    - Adds command "Get_log_file" which will write your SpaceX log out to the script-output folder.
+---------------------------------------------------------------------------------------------------
+Version: 0.3.13
+  Bugfixes:
+    - v0.3.13 redacted
+---------------------------------------------------------------------------------------------------
+Version: 0.3.12
+  Bugfixes:
+    - Fixes a rare crash on rocket launch event.
+---------------------------------------------------------------------------------------------------
+Version: 0.3.11
+  Bugfixes:
+    - Fixes an error on game close out
+---------------------------------------------------------------------------------------------------
+Version: 0.3.10
+  Changes:
+    - Added Russian language support courtesy of Zerggurat
+  Bugfixes:
+    - Performance issues with the SpaceX combinator resolved
+---------------------------------------------------------------------------------------------------
+Version: 0.3.9
+  Bugfixes:
+    - v0.3.9 redacted
+---------------------------------------------------------------------------------------------------
+Version: 0.3.8
+  Bugfixes:
+    - Remove spacex combinator debug information
+---------------------------------------------------------------------------------------------------
+Version: 0.3.7
+  Changes:
+    - Improved grammar in flavour text
+    - SpaceX Combinator introduced - will give accurate signal for current components needed to complete the current SpaceX phase. Current SpaceX phase given through virtual signal S - 1,2 or 3. Can be used to set filters/requester chests etc
+---------------------------------------------------------------------------------------------------
+Version: 0.3.6
+  Bugfixes:
+    - Under the Bob's mods integration, the technology price for faster than light theory D was incorrectly priced
+    - Under some circumstances the tech and recipe price multipliers were not working correctly
+    - The data handling has been reduced with the removal of data-updates script
+---------------------------------------------------------------------------------------------------
+Version: 0.3.5
+  Changes:
+    - The mod now works correctly in conjunction with scenarios that do not use silo script
+    - The mod now allows for multiple launching of SpaceX rockets - when the final SpaceX component is launched the player (or admin player in multiplayer scenario) is presented with an option to reset the SpaceX production counter, or end the game (latter option still offers the standard vanilla end game screen with options that include continue game, but in this case the SpaceX counter will not reset)
+    - The command "/resetSpaceX" will allow you to resume SpaceX launches on a map that has previously completed the full process (eg under an earlier version of this mod, or even on this version by mistake for example)
+    - Multiple SpaceX launches are logged with playtime stamp and ability to name/describe the launch event
+    - Flavour text added to SpaceX milestones courtesy of JD-Plays
+    - Oh, yes, Bob's mod integration is back baby!
+    - New mod setting allows for switching off bobs mods integration in case it causes any issues
+    - Bob coefficient inflates the cost of end game research under Bob mods integration to partially offset extreme over powered nature of end game Bobs mods. Currently, this coefficient is set to 10. In the hands of a good player, the highest tier bobs mods machines, modules, beacons and other easily provide 150 -250+ times the power of vanilla equivalents, so the coefficient at 10 is a very conservative clawback.
+---------------------------------------------------------------------------------------------------
+Version: 0.3.4 
+  Bugfixes:
+    - Launches after completing the spaceship victory will not spam victory message
+  Changes:
+    - Mod now supports mod_gui (refer ff#174)
+    - Colour and alignment added to Space Progress Summary
+---------------------------------------------------------------------------------------------------
+Version: 0.3.3
+  Bugfixes:
+    - v0.3.3 redacted
+---------------------------------------------------------------------------------------------------
+Version: 0.3.2
+  Changes:
+    - v0.16 compatibility
+  Bugfixes:
+    - Fix for headless server issue on configuration changed
+---------------------------------------------------------------------------------------------------
+Version: 0.3.1
+  Changes:
+    - Adds space science packs to last research (Faster than light propulsion systems)
+    - Minor update to mod start conditions
+    - In the start conditions, can opt out of having space science requirement in last SpaceX research
+    - In the start conditions can adjust the cost of the fusion reactor to 40 portable fusion reactors - this reduces the cost of the component so that it is equivalent to the cost it was under v0.14 (10k processing units instead of 25k processing units)
+    - In the start conditions can discount the tech costs by 4x to compensate for the marathon mode tech cost increases (at the default level). ie players can choose to use marathon costs for the vanilla game, and still use the standard tech costs once they start the SpaceX researches.
+---------------------------------------------------------------------------------------------------
+Version: 0.3.0
+  Changes:
+    - v0.15 compatibility
+    - Suppressed launch without satellite message
+    - SpaceX components can be auto launched with "auto launch with satellite setting" in rocket silo
+    - Ftl drive moved to last position of Space Progress Summary
+    - In space progress summary Hull sections renamed to Hull components to match name of item
+    - Item icons all changed to 32x32 square to conform with v0.15 standards
+    - Mod configuration added - research costs and production costs can be independently increased by multiples of 2 upto 16x classic cost. Required number of launches can be increased by 5x or by 25x - note all these launches require the base item, so effectively production cost and extended launches multiply together. These options are available from the mod settings menu.
+---------------------------------------------------------------------------------------------------
+Version: 0.2.3
+  Bugfixes:
+    - Corrected size of technology graphics so now they all look as intended rather than just left top corner
+    - Bob's mods technology/recipes will not be activated unless the following minimum Bob's modules are in use:
+      - Bob's library
+      - Bob's modules
+      - Bob's warfare
+      - Bob'e electronics
+    - This should fix any issues with "unusual" combinations of Bob's mods
+---------------------------------------------------------------------------------------------------
+Version: 0.2.2
+  Changes:
+    - Graphics update courtesy of Steinerrr
+      - New technology icons for all 15 techs (counting ftl as 4 techs)
+      - New item icons for Assembly robot, Drydock Structural Component, Drydock Assembly Component, Hull Component, Protection Field, Fusion Reactor, Spaceship Thruster, Fuel Cell, Command Center, FTL Drive 
+---------------------------------------------------------------------------------------------------
+Version: 0.2.1
+  Bugfixes:
+    - Fixed an issue where the Drydock completed message could be prematurely generated
+    - Fixed an issue where Angels infinite ores used without Bobs mods caused an error on loading factorio
+  Changes:
+    - Bob's mods integration - added an alternate recipe for the spaceship protection field to remove the (excessive) multi-colored alien goo farming required
+---------------------------------------------------------------------------------------------------
+Version: 0.2.0
+  Bugfixes:
+    - Fixed space progress reference to Drydock Command - this is now identified as the Drydock assembly component (like the item that needs to be launched
+    - Corrected endgame console victory message for minor spelling error in "achieved"
+    - Fixed the graphic for the life support icon
+  Changes:
+    - Added Bob's Mod integration based on bob's mod configuration:
+    - Satellite recipe uses radar 5s, advanced processing unit, large solar panel mk 3s,large accumulator mk 3s
+    - Low density structure uses titanium and nitinol in the place of steel and copper
+    - Habitation component uses titanium and advanced processing unit to replace steel and processing unit
+    - Fuel cell component uses titanium and advanced processing unit to replace steel and processing unit
+    - Protection field component uses energy shield mk 6 to replace energy shield mk 2
+    - Hull component uses titanium in place of steel
+    - Fusion Reactor component uses fusion reactor mk 4 in place of fusion reactor equipment
+    - Drydock assembly component uses large solar panel mk3, roboport mk 4, and advanced processing units in place of vanila items
+    - All module requirements become god module 5s if god modules employed, otherwise the lvl 8 module version is used in the following -
+    - Assembly robot which also uses construction robot mk 4
+    - Space thruster which also uses titanium pipe and advanced processing unit
+    - Life support which also uses titanium pipe and advanced processing unit
+    - Command Centre which also uses advanced processing unit
+    - Astrometrics which also uses advanced processing unit
+    - FTL drive which also uses advanced processing unit
+    - Bob's mods technology changes
+    - If the dark blue science pack is available then all SpaceX techs that required the 4 vanilla sciences now also require dark blue
+    - In addition, the ftl drive becomes 5 parts of 200k research each
+    - SpaceX research is adjusted to include pre-requisites to the appropriate bob's mods techs
+    - Space Assembly technology has the module pre-requisites added
+    - Rocket silo now also requires titanium process, nitinol processing, electric energy accumulators mk4 , solar energy mk 4, advanced electronics 3, and radars 4
+    - Space Construction additionally needs Modular robo ports 4
+    - Protection fields needs Energy shield equipment mk 6
+    - Fusion reactor needs Fusion Reactor equipment mk 4

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.3
+  Bugfixes:
+    - Fixed unresearchable techs with Bob's mods and Angel's Industries Technology Overhaul
+---------------------------------------------------------------------------------------------------
 Version: 1.1.2
   Changes:
     - Add compatibility for Better Victory Screen (by stringweasel)

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "SpaceMod",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "title": "Space Extension Mod",
   "author": "LordKTor",
   "description": "Greatly extend the end game requiring multiple launches and massively increased science. Requires 40+ launches, and of a variety of new components. The goal is to build a vessel capable of getting you off the planet and home safely. Updated graphics courtesy of Steinerrr ",

--- a/prototypes/technology-bobs.lua
+++ b/prototypes/technology-bobs.lua
@@ -1,98 +1,95 @@
 local bob_coefficient = 10
 local researchCost = settings.startup["SpaceX-research"].value
 if researchCost == nil then
-	researchCost = 1
+  researchCost = 1
 end
 
 local SpaceXTechs = {
-"space-assembly",
-"space-construction",
-"space-casings",
-"protection-fields",
-"fusion-reactor",
-"space-thrusters",
-"fuel-cells",
-"habitation",
-"life-support-systems",
-"spaceship-command",
-"astrometrics",
-"ftl-theory-A",
-"ftl-theory-B",
-"ftl-theory-C",
-"ftl-theory-D1",
-"ftl-theory-D2",
-"ftl-propulsion",
+  "space-assembly",
+  "space-construction",
+  "space-casings",
+  "protection-fields",
+  "fusion-reactor",
+  "space-thrusters",
+  "fuel-cells",
+  "habitation",
+  "life-support-systems",
+  "spaceship-command",
+  "astrometrics",
+  "ftl-theory-A",
+  "ftl-theory-B",
+  "ftl-theory-C",
+  "ftl-theory-D1",
+  "ftl-theory-D2",
+  "ftl-propulsion",
 }
 
-if data.raw.tool["advanced-logistic-science-pack"] then
+if bobmods.tech and bobmods.tech.advanced_logistic_science then
+  table.insert(SpaceXTechs, "ftl-theory-D")
 
-	table.insert(SpaceXTechs, "ftl-theory-D")
-
-    data:extend(
+  data:extend({
     {
-		{
-		type = "technology",
-		name = "ftl-theory-D",
-		icon = "__SpaceMod__/graphics/technology/ftl.png",	
-		icon_size = 128,
-		prerequisites = {"ftl-theory-C"},
-		unit =
-		{
-		count = 200000 * researchCost,
-		ingredients =
-		{
-			{"automation-science-pack", 1},
-			{"logistic-science-pack", 1},
-			{"chemical-science-pack", 1},
-			{"advanced-logistic-science-pack", 1},
-		},
-		time = 60
-		},
-		order = "k-o-a"
-	}
-	}
-	)
+      type = "technology",
+      name = "ftl-theory-D",
+      icon = "__SpaceMod__/graphics/technology/ftl.png",  
+      icon_size = 128,
+      prerequisites = {"ftl-theory-C"},
+      unit =
+        {
+          count = 200000 * researchCost,
+          ingredients =
+          {
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
+            {"chemical-science-pack", 1},
+            {"advanced-logistic-science-pack", 1},
+          },
+          time = 60
+        },
+      order = "k-o-a"
+    }
+  })
 
-	bobmods.lib.tech.add_science_pack("space-assembly", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("space-construction", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("space-casings", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("protection-fields", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("fusion-reactor", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("space-thrusters", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("fuel-cells", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("habitation", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("life-support-systems", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("spaceship-command", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("astrometrics", "advanced-logistic-science-pack", 1)
-	bobmods.lib.tech.add_science_pack("ftl-propulsion", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("space-assembly", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("space-construction", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("space-casings", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("protection-fields", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("fusion-reactor", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("space-thrusters", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("fuel-cells", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("habitation", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("life-support-systems", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("spaceship-command", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("astrometrics", "advanced-logistic-science-pack", 1)
+  bobmods.lib.tech.add_science_pack("ftl-propulsion", "advanced-logistic-science-pack", 1)
 
 
-    data.raw.technology["ftl-theory-A"].unit.count = 200000 * researchCost
-    data.raw.technology["ftl-theory-B"].unit.count = 200000 * researchCost
-    data.raw.technology["ftl-theory-C"].unit.count = 200000 * researchCost
-	data.raw.technology["ftl-theory-D1"].unit.count = 200000 * researchCost
-	data.raw.technology["ftl-theory-D2"].unit.count = 200000 * researchCost
-    data.raw.technology["ftl-propulsion"].unit.count = 200000 * researchCost
+  data.raw.technology["ftl-theory-A"].unit.count = 200000 * researchCost
+  data.raw.technology["ftl-theory-B"].unit.count = 200000 * researchCost
+  data.raw.technology["ftl-theory-C"].unit.count = 200000 * researchCost
+  data.raw.technology["ftl-theory-D1"].unit.count = 200000 * researchCost
+  data.raw.technology["ftl-theory-D2"].unit.count = 200000 * researchCost
+  data.raw.technology["ftl-propulsion"].unit.count = 200000 * researchCost
 
-    bobmods.lib.tech.replace_prerequisite("ftl-theory-D1", "ftl-theory-C", "ftl-theory-D")
-    bobmods.lib.tech.replace_prerequisite("ftl-theory-D2", "ftl-theory-C", "ftl-theory-D")	
+  bobmods.lib.tech.replace_prerequisite("ftl-theory-D1", "ftl-theory-C", "ftl-theory-D")
+  bobmods.lib.tech.replace_prerequisite("ftl-theory-D2", "ftl-theory-C", "ftl-theory-D")  
 
 end
 
-bobmods.lib.tech.add_prerequisite("space-assembly", "bob-robots-3")	
+bobmods.lib.tech.add_prerequisite("space-assembly", "bob-robots-3")  
 
 if bobmods.modules.EnableGodModules == true then
-	bobmods.lib.tech.add_prerequisite("space-assembly", "god-module-5")
+  bobmods.lib.tech.add_prerequisite("space-assembly", "god-module-5")
 --    data.raw.technology["space-assembly"].prerequisites = {"god-module-5","rocket-silo","bob-robots-3"}
 else
-	bobmods.lib.tech.add_prerequisite("space-assembly", "speed-module-8")
-	bobmods.lib.tech.add_prerequisite("space-assembly", "effectivity-module-8")
+  bobmods.lib.tech.add_prerequisite("space-assembly", "speed-module-8")
+  bobmods.lib.tech.add_prerequisite("space-assembly", "effectivity-module-8")
 --    data.raw.technology["space-assembly"].prerequisites = {"speed-module-8","effectivity-module-8","rocket-silo","bob-robots-3"}
-	bobmods.lib.tech.add_prerequisite("ftl-propulsion", "productivity-module-8")
---    data.raw.technology["ftl-propulsion"].prerequisites = {"productivity-module-8","ftl-theory-D"}	
+  bobmods.lib.tech.add_prerequisite("ftl-propulsion", "productivity-module-8")
+--    data.raw.technology["ftl-propulsion"].prerequisites = {"productivity-module-8","ftl-theory-D"}  
 end
 
-bobmods.lib.tech.add_prerequisite("space-construction", "bob-robo-modular-4")	
+bobmods.lib.tech.add_prerequisite("space-construction", "bob-robo-modular-4")  
 -- data.raw.technology["space-construction"].prerequisites = {"space-assembly","bob-robo-modular-4"}
 bobmods.lib.tech.add_prerequisite("protection-fields", "bob-energy-shield-equipment-6")
 -- data.raw.technology["protection-fields"].prerequisites = {"space-construction","energy-shield-equipment-6"}
@@ -111,8 +108,8 @@ bobmods.lib.tech.add_recipe_unlock("protection-fields", "protection-field-goople
 
 -- Nerf Bob's end game
 for i, tech in pairs(SpaceXTechs) do
-	local rootTech = data.raw.technology[tech]
-	if rootTech ~= nil then
-		rootTech.unit.count = rootTech.unit.count * bob_coefficient
-	end
+  local rootTech = data.raw.technology[tech]
+  if rootTech ~= nil then
+    rootTech.unit.count = rootTech.unit.count * bob_coefficient
+  end
 end


### PR DESCRIPTION
When Angel's Industries mod setting "Technology Overhaul" is enabled, regular science packs should not be used. The SpaceX techs can't be researched as they use the pink "Logistic Science Pack".

![image](https://github.com/billbo99/SpaceMod/assets/59639/9ea0ddf5-b449-4b65-829d-dc53a445d24d)

Minimum mod list:
- Angel's Bioprocessing
- Angel's Industries (tech overhaul)
- Angel's Petrochemical Processing
- Angel's Refining
- Angel's Smelting
- Bob's Electronics
- Bob's Functions Library
- Bob's Logistics
- Bob's Metals, Chemicals, and Intermediates
- Bob's Modules
- Bob's Ores
- Bob's Personal Equipment
- Bob's Technology

---
Reformat changelog so it can be viewed in game